### PR TITLE
Pin coursier sbt app to the 1.x runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          apps: sbt
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.84.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+ and parses CLI commands differently. Kept in
+          # sync with sbt releases by Renovate.
+          apps: sbt:1.12.12
       - uses: actions/setup-node@v6
         with:
           node-version: 24.15.0

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,20 @@
   "extends": [
     "config:recommended"
   ],
-  "enabledManagers": ["github-actions", "npm"]
+  "enabledManagers": ["github-actions", "npm", "custom.regex"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["apps: sbt:(?<currentValue>\\S+)"],
+      "depNameTemplate": "org.scala-sbt:sbt-launch",
+      "datasourceTemplate": "maven"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.scala-sbt:sbt-launch"],
+      "allowedVersions": "<2.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Pin `apps: sbt:1.12.12` on every `coursier/setup-action` step (`test.yml`, `release.yml`, `scala-steward.yml`). The latest `apps: sbt` runner is sbt 2.x, which requires JDK 17+ and parses CLI commands differently; `release.yml` and `test.yml` previously relied on whatever sbt the GitHub runner ships and now use the explicit 1.x runner matching the project's own `sbt.version`.
- Add a Renovate custom manager that tracks `org.scala-sbt:sbt-launch` from the `apps: sbt:<version>` line, capped to `<2.0.0`, so the pin stays in sync with sbt releases. Also enable `custom.regex` so the manager runs given this repo's restricted `enabledManagers`.
- Adapted from ptrdom/scalajs-esbuild#656.

Generated with [Claude Code](https://claude.com/claude-code)