### PR TITLE
Cap sbt-launch pin below 1.12.13 to keep the sbt 1.x runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+. Renovate is constrained to
+          # not bump past this in renovate.json.
+          apps: sbt:1.12.12
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.84.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,11 @@ jobs:
       - uses: coursier/setup-action@v3
         with:
           jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+ and parses CLI commands differently. Kept in
-          # sync with sbt releases by Renovate.
-          apps: sbt:1.12.13
+          # Pin to the last sbt 1.x-default launcher: 1.12.13+ defaults to the
+          # sbt 2.x runner, which requires JDK 17+ (breaking the JDK 8 matrix)
+          # and parses CLI commands differently. Renovate is constrained to not
+          # bump past this in renovate.json.
+          apps: sbt:1.12.12
       - uses: actions/setup-node@v6
         with:
           node-version: 24.18.0

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,9 @@
   ],
   "packageRules": [
     {
+      "description": "sbt-launch 1.12.13+ defaults to the sbt 2.x runner, which requires JDK 17+ and breaks the JDK 8 test matrix. Pin to the last sbt 1.x-default launcher.",
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
-      "allowedVersions": "<2.0.0"
+      "allowedVersions": "<1.12.13"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ports [ptrdom/scalajs-esbuild#672](https://github.com/ptrdom/scalajs-esbuild/pull/672) to this repo.

The sbt launcher was bumped to 1.12.13 by Renovate (#465). The 1.12.13+ launcher defaults to the sbt 2.x runner, which requires JDK 17+ and parses CLI commands differently. This broke the JDK 8 test matrix and the Scala Steward job (sbt 2.x requires JDK 17 or above, but the runner uses JDK 11).

This pins all workflows back to 1.12.12 (the last sbt 1.x-default launcher) and tightens the Renovate `allowedVersions` constraint from `<2.0.0` to `<1.12.13` so future automated bumps stay on the sbt 1.x runner.

## Changes

- `test.yml`, `scala-steward.yml`, `release.yml`: pin `apps: sbt:1.12.13` to `1.12.12` and update the rationale comment.
- `renovate.json`: change `allowedVersions` to `<1.12.13` and add a `description` explaining the constraint.

Generated with [Claude Code](https://claude.com/claude-code)
