### PR TITLE
Run the Scala Steward job on JDK 17

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: coursier/setup-action@v3
         with:
-          jvm: temurin:11
-          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
-          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
+          # scala-steward-action v2.90.0 bundles its own sbt 2.x runner, which
+          # requires JDK 17+ regardless of the stewarded project's sbt version.
+          jvm: temurin:17
           apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.90.0


### PR DESCRIPTION
## Summary

Bumps the Scala Steward job to JDK 17. `scala-steward-action` v2.90.0 bundles its own sbt 2.x runner, which requires JDK 17+ regardless of the stewarded project's sbt version. Running the job on JDK 11 failed as soon as Scala Steward tried to extract project dependencies.

Ports [ptrdom/scalajs-esbuild#673](https://github.com/ptrdom/scalajs-esbuild/pull/673) to this repo.

Generated with [Claude Code](https://claude.com/claude-code)