### PR TITLE
Add scala-steward-hooks project to keep scripted test deps updated

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ inThisBuild(
 
 lazy val `scalajs-vite` = (project in file("."))
   .settings(publish / skip := true)
-  .aggregate(`sbt-scalajs-vite`, `sbt-web-scalajs-vite`)
+  .aggregate(`sbt-scalajs-vite`, `sbt-web-scalajs-vite`, `scala-steward-hooks`)
 
 lazy val commonSettings = Seq(
   scriptedLaunchOpts ++= Seq(
@@ -56,7 +56,39 @@ TaskKey[Unit]("scriptedSequentialPerModule") := {
     val projects: Seq[ProjectReference] = `scalajs-vite`.aggregate
     Def
       .sequential(
-        projects.map(p => Def.taskDyn((p / scripted).toTask("")))
+        projects.map(p =>
+          Def.taskDyn {
+            (p / scripted).?.value match {
+              case Some(_) => (p / scripted).toTask("")
+              case None    => Def.task(())
+            }
+          }
+        )
       )
   }.value
 }
+
+// Declares the library dependencies used in the scripted tests so that Scala
+// Steward keeps them up to date. The scripted test build definitions are not
+// part of this build, so without this project Scala Steward would not discover
+// these dependencies. The versions here must match the ones used in the
+// scripted tests for Scala Steward's version replacement to reach them.
+lazy val `scala-steward-hooks` = project
+  .in(file("scala-steward-hooks"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    publish / skip := true,
+    scalaVersion := "2.13.17",
+    libraryDependencies ++= Seq(
+      "org.scala-js" %%% "scalajs-dom" % "2.2.0",
+      "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0",
+      "org.scalatest" %%% "scalatest" % "3.2.17",
+      "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.16",
+      "org.scalatestplus" %% "selenium-4-9" % "3.2.16.0",
+      "org.seleniumhq.selenium" % "selenium-java" % "4.12.1",
+      "org.scala-js" %% "scalajs-env-jsdom-nodejs" % "1.1.1",
+      "com.typesafe.akka" %% "akka-actor-typed" % "2.6.20",
+      "com.typesafe.akka" %% "akka-stream" % "2.6.20",
+      "com.typesafe.akka" %% "akka-http" % "10.2.10"
+    )
+  )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.2")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")
+
+// only needed for `scala-steward-hooks`
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")

--- a/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/build.sbt
+++ b/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/build.sbt
@@ -102,6 +102,6 @@ lazy val `integration-test` = (project in file("integration-test"))
     }.value,
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scala-js-macrotask-executor" % "1.0.0" % "test",
-      "org.scalatest" %%% "scalatest" % "3.2.15" % "test"
+      "org.scalatest" %%% "scalatest" % "3.2.17" % "test"
     )
   )


### PR DESCRIPTION
## Summary

Scripted test build definitions live under `src/sbt-test` and are not part of this build, so Scala Steward never resolves them and their library versions go stale (e.g. `scalajs-dom` was pinned at `2.2.0`). This mirrors the [scalajs-esbuild `scala-steward-hooks` pattern](https://github.com/ptrdom/scalajs-esbuild/blob/main/build.sbt#L108-L125): a dummy project that declares those same dependencies in the main build, so Scala Steward discovers them and its repo-wide version-string replacement reaches the scripted build files too.

## Changes

- Add the `scala-steward-hooks` Scala.js project declaring every library dependency used across the scripted tests, and aggregate it under the root project.
- Add `sbt-scalajs` to `project/plugins.sbt` (needed only so `ScalaJSPlugin` and `%%%` are available to the hooks project).
- Guard `scriptedSequentialPerModule` with `.?` so aggregated projects without a `scripted` task (the hooks project) are skipped.
- Align `scalatest` `3.2.15` -> `3.2.17` in the electron scripted test, so a single hooks declaration keeps every scripted test in sync.

## Notes

- Versions in `scala-steward-hooks` intentionally mirror the current versions in the scripted tests. On its next run Scala Steward bumps them and propagates the new strings into the scripted build files.
- `akka` is exposed here just like esbuild exposes `pekko`. If Akka bumps are undesirable (post-2.6.x license change), pin it in `.scala-steward.conf`.

Generated with [Claude Code](https://claude.com/claude-code)