### PR TITLE
Update scala to 2.13.18

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,7 @@ lazy val `scala-steward-hooks` = project
   .enablePlugins(ScalaJSPlugin)
   .settings(
     publish / skip := true,
-    scalaVersion := "2.13.17",
+    scalaVersion := "2.13.18",
     libraryDependencies ++= Seq(
       "org.scala-js" %%% "scalajs-dom" % "2.8.1",
       "org.scala-js" %%% "scala-js-macrotask-executor" % "1.1.1",

--- a/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/basic-project/build.sbt
+++ b/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/basic-project/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSVitePlugin)
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.18"
 
 scalaJSUseMainModuleInitializer := true
 

--- a/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/build.sbt
+++ b/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/build.sbt
@@ -6,7 +6,7 @@ import scala.sys.process._
 lazy val root = (project in file("."))
   .aggregate(app, `integration-test`)
 
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.18"
 
 val viteElectronBuildPackage =
   taskKey[Unit]("Generate package directory with electron-builder")

--- a/sbt-web-scalajs-vite/src/sbt-test/sbt-web-scalajs-vite/basic-project/build.sbt
+++ b/sbt-web-scalajs-vite/src/sbt-test/sbt-web-scalajs-vite/basic-project/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.17"
+ThisBuild / scalaVersion := "2.13.18"
 
 lazy val `basic-project` = (project in file(".")).aggregate(client, server)
 


### PR DESCRIPTION
Bumps Scala from 2.13.17 to 2.13.18 in the build and across the scripted test build definitions.

Generated with [Claude Code](https://claude.com/claude-code)