### PR TITLE
Pin sbt and scalafmt versions for Scala Steward

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -13,15 +13,20 @@ jobs:
     runs-on: ubuntu-24.04
     name: Launch Scala Steward
     steps:
+      - uses: coursier/cache-action@v8
       - uses: coursier/setup-action@v3
         with:
-          # scala-steward-action v2.90.0 bundles its own sbt 2.x runner, which
-          # requires JDK 17+ regardless of the stewarded project's sbt version.
-          jvm: temurin:17
+          jvm: temurin:11
+          # Pin to the sbt 1.x runner: the latest runner is sbt 2.x, which
+          # requires JDK 17+. Kept in sync with sbt releases by Renovate.
           apps: sbt:1.12.13
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
+          # Pin the sbt and scalafmt versions Scala Steward runs against to the
+          # ones used in this repository. Kept in sync by Renovate.
+          sbt-version: 1.12.13
+          scalafmt-version: 3.11.1
           github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
           github-app-installation-id: ${{ secrets.SCALA_STEWARD_APP_INSTALLATION_ID }}
           github-app-key: ${{ secrets.SCALA_STEWARD_APP_PRIVATE_KEY }}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,1 +1,8 @@
 updatePullRequests = "always"
+
+# sbt and scalafmt versions are pinned and updated by Renovate instead
+# (project/build.properties, .scalafmt.conf and the scala-steward workflow).
+updates.ignore = [
+  { groupId = "org.scala-sbt", artifactId = "sbt" },
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
+]

--- a/renovate.json
+++ b/renovate.json
@@ -8,15 +8,46 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
-      "matchStrings": ["apps: sbt:(?<currentValue>\\S+)"],
+      "matchStrings": [
+        "apps: sbt:(?<currentValue>\\S+)",
+        "sbt-version: (?<currentValue>\\S+)"
+      ],
       "depNameTemplate": "org.scala-sbt:sbt-launch",
       "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["scalafmt-version: (?<currentValue>\\S+)"],
+      "depNameTemplate": "scalameta/scalafmt",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^project/build\\.properties$/"],
+      "matchStrings": ["sbt\\.version\\s*=\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "org.scala-sbt:sbt-launch",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.scalafmt\\.conf$/"],
+      "matchStrings": ["version\\s*=\\s*(?<currentValue>\\S+)"],
+      "depNameTemplate": "scalameta/scalafmt",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [
     {
       "matchPackageNames": ["org.scala-sbt:sbt-launch"],
+      "groupName": "sbt",
       "allowedVersions": "<2.0.0"
+    },
+    {
+      "matchPackageNames": ["scalameta/scalafmt"],
+      "groupName": "scalafmt"
     }
   ]
 }


### PR DESCRIPTION
Ports [ptrdom/scalajs-esbuild#675](https://github.com/ptrdom/scalajs-esbuild/pull/675) to this repo. Pins the sbt and scalafmt versions that Scala Steward runs against to the ones used in this repository, with Renovate keeping them in sync. (The scala-steward-action v2.92.0 bump from that PR already landed here via #480.)

## Changes

`.github/workflows/scala-steward.yml`
- Add `coursier/cache-action@v8`.
- Run on the sbt 1.x runner under JDK 11 (the latest runner is sbt 2.x, which requires JDK 17+).
- Pin `sbt-version: 1.12.13` and `scalafmt-version: 3.11.1` to the versions used in this repository.

`.scala-steward.conf`
- Ignore `org.scala-sbt:sbt` and `org.scalameta:scalafmt-core`, since Renovate now manages those versions.

`renovate.json`
- Add regex managers for `sbt-version`/`scalafmt-version` in workflows, `sbt.version` in `project/build.properties`, and `version` in `.scalafmt.conf`.
- Group sbt/scalafmt updates and keep the existing `<2.0.0` cap on sbt.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>