### PR TITLE
Pin rolldown to 1.1.3 in scripted vite fixtures

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,6 +48,11 @@
     {
       "matchPackageNames": ["scalameta/scalafmt"],
       "groupName": "scalafmt"
+    },
+    {
+      "description": "rolldown is pinned via overrides/resolutions in the scripted vite fixtures to work around a runtime regression in 1.1.4 (vite's ~1.1.3 range otherwise floats to it and breaks the jsdom test bundle). Remove the pin once a fixed rolldown ships.",
+      "matchPackageNames": ["rolldown"],
+      "groupName": "rolldown"
     }
   ]
 }

--- a/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/basic-project/vite/package.json
+++ b/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/basic-project/vite/package.json
@@ -6,5 +6,11 @@
   "devDependencies": {
     "vite": "8.1.2",
     "jsdom": "29.1.1"
+  },
+  "overrides": {
+    "rolldown": "1.1.3"
+  },
+  "resolutions": {
+    "rolldown": "1.1.3"
   }
 }

--- a/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/app/vite/package.json
+++ b/sbt-scalajs-vite/src/sbt-test/sbt-scalajs-vite/electron-project/app/vite/package.json
@@ -12,5 +12,11 @@
     "vite-plugin-electron": "1.1.0",
     "vite": "8.1.2",
     "playwright": "1.61.1"
+  },
+  "overrides": {
+    "rolldown": "1.1.3"
+  },
+  "resolutions": {
+    "rolldown": "1.1.3"
   }
 }

--- a/sbt-web-scalajs-vite/src/sbt-test/sbt-web-scalajs-vite/basic-project/client/vite/package.json
+++ b/sbt-web-scalajs-vite/src/sbt-test/sbt-web-scalajs-vite/basic-project/client/vite/package.json
@@ -5,5 +5,11 @@
   "type": "module",
   "devDependencies": {
     "vite": "8.1.2"
+  },
+  "overrides": {
+    "rolldown": "1.1.3"
+  },
+  "resolutions": {
+    "rolldown": "1.1.3"
   }
 }


### PR DESCRIPTION
## Why CI is red on every open PR

The failures are not caused by the PRs themselves. `main` last built green on 2026-07-01 10:30 UTC; every run since fails on the vite scripted tests, including PRs that only touch electron or sbt-ci-release. All fixtures pin `vite: 8.1.2`, identical to the last green config.

The real cause is one level down. `vite` depends on `rolldown` via `~1.1.3`, and `rolldown@1.1.4` was published on 2026-07-01 14:01 UTC, right after the last green run. Since the scripted tests delete the lockfile and reinstall from scratch on every run, every install since then floats up to `1.1.4`, which miscompiles the linked Scala.js output. It surfaces in two different ways depending on the fixture:

- `sbt-scalajs-vite/basic-project`: the minified test bundle throws at runtime under the jsdom `JSEnv` (crash in `__.handleMessage__T__V`, exit code 1) and the `test` step fails.
- `sbt-web-scalajs-vite/basic-project`: `String.stripMargin` is corrupted, so the browser renders `| basic-project-sbt-web works! |` (margin bars not stripped) and the `html` assertion fails.

## The fix

Pin `rolldown` to the last-good `1.1.3` via `overrides` (npm/pnpm) and `resolutions` (yarn) in all three vite fixtures: `sbt-scalajs-vite/basic-project`, `sbt-scalajs-vite/electron-project`, and `sbt-web-scalajs-vite/basic-project`.

## Verification

Reproduced the jsdom crash locally with a fresh install (`rolldown@1.1.4`): scripted `sbt-scalajs-vite/basic-project` crashes at `{line 18} test failed`, byte-for-byte matching CI (same `index-D7GCPNZa.js`, 1,770 kB). With the pin applied, both the FastOpt and FullOpt `test` stages report `All tests passed` and the crash signature is gone. The `sbt-web` `stripMargin` corruption was diagnosed from the CI failure on this PR's first push, which pinned only the first two fixtures.

## Renovate

Renovate's npm manager tracks the `overrides`/`resolutions` entries, so the pin is not a dead end. It will open an update PR for each new `rolldown` release. The bump to `1.1.4` will surface as a failing PR, a useful signal that `1.1.4` is still broken; once a fixed release ships, its PR will go green and the pin can be lifted. A `packageRule` in `renovate.json` documents the rationale and groups all fixtures into one PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
