### PR TITLE
Pin Scala Steward to 0.39.0, the last Java 11 build

### DIFF
--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2.92.0
         with:
+          # Pin Scala Steward itself. The action otherwise downloads the latest
+          # published version on every run; 0.39.1 dropped the Java 11 build and
+          # requires Java 17+, which breaks the temurin:11 runner above. Renovate
+          # tracks this pin; a bump past 0.39.0 fails on first run until the
+          # runner is moved to JDK 17.
+          scala-steward-version: 0.39.0
           # Pin the sbt and scalafmt versions Scala Steward runs against to the
           # ones used in this repository. Kept in sync by Renovate.
           sbt-version: 1.12.13

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
     },
     {
       "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
+      "matchStrings": ["scala-steward-version: (?<currentValue>\\S+)"],
+      "depNameTemplate": "scala-steward-org/scala-steward",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
       "managerFilePatterns": ["/^project/build\\.properties$/"],
       "matchStrings": ["sbt\\.version\\s*=\\s*(?<currentValue>\\S+)"],
       "depNameTemplate": "org.scala-sbt:sbt-launch",
@@ -48,6 +56,11 @@
     {
       "matchPackageNames": ["scalameta/scalafmt"],
       "groupName": "scalafmt"
+    },
+    {
+      "description": "Pinned to 0.39.0, the last Java 11 build; 0.39.1+ requires Java 17+ and will fail on the temurin:11 runner in scala-steward.yml. Bump PRs are intentionally left uncapped: a bump beyond 0.39.0 fails first run and is resolved by moving the runner to JDK 17.",
+      "matchPackageNames": ["scala-steward-org/scala-steward"],
+      "groupName": "scala-steward"
     },
     {
       "description": "rolldown is pinned via overrides/resolutions in the scripted vite fixtures to work around a runtime regression in 1.1.4 (vite's ~1.1.3 range otherwise floats to it and breaks the jsdom test bundle). Remove the pin once a fixed rolldown ships.",


### PR DESCRIPTION
Scala Steward 0.39.1 dropped the Java 11 build and now requires Java 17+, which conflicts with the `temurin:11` runner in `scala-steward.yml`. Because the action downloads the latest published version on every run, this pins it to 0.39.0 to prevent breakage.

## Changes

- `.github/workflows/scala-steward.yml` -- adds `scala-steward-version: 0.39.0` with an explanatory comment.
- `renovate.json` -- adds a custom regex manager that tracks the pin against GitHub releases and groups bump PRs under scala-steward. Bumps are left uncapped: a bump past 0.39.0 fails on first run and is resolved by moving the runner to JDK 17.

Generated with [Claude Code](https://claude.com/claude-code)