### PR TITLE
Track scalafmt through Maven Central instead of GitHub releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,9 +19,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/^\\.github/workflows/.*\\.ya?ml$/"],
       "matchStrings": ["scalafmt-version: (?<currentValue>\\S+)"],
-      "depNameTemplate": "scalameta/scalafmt",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "depNameTemplate": "org.scalameta:scalafmt-cli_2.13",
+      "datasourceTemplate": "maven"
     },
     {
       "customType": "regex",
@@ -42,9 +41,8 @@
       "customType": "regex",
       "managerFilePatterns": ["/^\\.scalafmt\\.conf$/"],
       "matchStrings": ["version\\s*=\\s*(?<currentValue>\\S+)"],
-      "depNameTemplate": "scalameta/scalafmt",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "depNameTemplate": "org.scalameta:scalafmt-cli_2.13",
+      "datasourceTemplate": "maven"
     }
   ],
   "packageRules": [
@@ -54,7 +52,8 @@
       "allowedVersions": "<2.0.0"
     },
     {
-      "matchPackageNames": ["scalameta/scalafmt"],
+      "description": "Tracked through the Maven artifact coursier resolves (org.scalameta::scalafmt-cli, _2.13 being coursier's default Scala version) rather than the GitHub release: the release tag lands hours before the JARs reach Maven Central, and a bump PR opened in that window fails in scala-steward-action's `cs install scalafmt:<version>`.",
+      "matchPackageNames": ["org.scalameta:scalafmt-cli_2.13"],
       "groupName": "scalafmt"
     },
     {


### PR DESCRIPTION
## Summary

Renovate tracked both scalafmt pins (`scalafmt-version:` in the Scala Steward workflow and `version =` in `.scalafmt.conf`) through the `github-releases` datasource. The GitHub release tag appears hours before the artifacts sync to Maven Central, so a bump PR opened in that window fails CI: `scala-steward-action` runs `cs install scalafmt:<version>`, which resolves `org.scalameta:scalafmt-cli_2.13` from Central and aborts with `✕ Unable to install managed tools`. The underlying coursier error is invisible in the log — the action runs `cs` with `silent: true` and routes its output to `core.debug`.

Concretely: `scalafmt-cli_2.13` 3.11.5 reached Maven Central at 2026-07-27 13:22 UTC, and the scalafmt bump PR's Scala Steward dry run failed at 02:36 that day for exactly this reason.

Both custom managers now use the `maven` datasource on `org.scalameta:scalafmt-cli_2.13` — the artifact coursier resolves — so a bump PR is only raised once the version is actually downloadable. This matches how the sbt pins (`org.scala-sbt:sbt-launch`) are already tracked in this config.

The current pin, 3.11.5, is the latest version on Central, so this change should not produce a new bump PR on its own. Verified with `renovate-config-validator`.

Generated with [Claude Code](https://claude.com/claude-code)
